### PR TITLE
feat: inject styles in shadowRoot + ref for ReactElement

### DIFF
--- a/lit-react-wrapper.js
+++ b/lit-react-wrapper.js
@@ -1,44 +1,58 @@
-import { html, LitElement } from 'lit';
-import * as ReactDOM from 'react-dom';
-import * as React from 'react';
-import * as retargetEvents from 'react-shadow-dom-retarget-events';
-import { StylesProvider, jssPreset } from '@material-ui/styles';
-import { create } from 'jss';
-
+import { html, LitElement } from "lit";
+import * as ReactDOM from "react-dom";
+import * as React from "react";
+import * as retargetEvents from "react-shadow-dom-retarget-events";
+import { StylesProvider, jssPreset } from "@material-ui/styles";
+import { create } from "jss";
 
 export class LitReactWrapper extends LitElement {
-  
-  static get properties(){
+  static get properties() {
     return {
       mountPoint: Object,
       props: Object,
-      element: Object
-    }
+      element: Object,
+      styles: String,
+      styleElement: Object,
+    };
   }
-  
-  constructor(){
+
+  constructor() {
     super();
-    this.props={};
+    this.props = {};
+    this.styles = [];
+    this.styleElement = null;
   }
-  
+
   render() {
-    return html`
-      <div id="mountPoint"></div>
-    `;
+    return html` <div id="mountPoint"></div> `;
   }
 
   createElement() {
     const props = this.props || {};
-    if(!props.mountContainer) props.mountContainer = this.mountPoint;
-    if(!props.mountDocument) props.mountDocument = this.shadowRoot || document;
+    if (!props.mountContainer) props.mountContainer = this.mountPoint;
+    if (!props.mountDocument) props.mountDocument = this.shadowRoot || document;
     this.reactElement = React.createElement(this.element, props, React.createElement("slot"));
     return this.reactElement;
   }
-  
-  renderElement(){
+
+  injectStyles() {
+    if (this.styleElement && this.shadowRoot.contains(this.styleElement)) {
+      this.shadowRoot.removeChild(this.styleElement);
+    }
+
+    const styleContent = Array.isArray(this.styles) ? this.styles.join("\n") : this.styles;
+
+    if (styleContent) {
+      this.styleElement = document.createElement("style");
+      this.styleElement.textContent = styleContent;
+      this.shadowRoot.insertBefore(this.styleElement, this.mountPoint);
+    }
+  }
+
+  renderElement() {
     const jss = create({
       ...jssPreset(),
-      insertionPoint: this.mountPoint
+      insertionPoint: this.mountPoint,
     });
     ReactDOM.render(
       <StylesProvider jss={jss} sheetsManager={new Map()}>
@@ -49,16 +63,20 @@ export class LitReactWrapper extends LitElement {
   }
 
   firstUpdated() {
-    this.mountPoint = this.shadowRoot.getElementById('mountPoint');
+    this.mountPoint = this.shadowRoot.getElementById("mountPoint");
+    this.injectStyles();
     this.renderElement();
     retargetEvents(this.shadowRoot);
   }
 
-  updated(changedProperties){
-    if(changedProperties)
+  updated(changedProperties) {
+    if (changedProperties.has("styles") || changedProperties.has("element")) {
+      this.injectStyles();
+    }
+    if (changedProperties.has("props") || changedProperties.has("element")) {
       this.renderElement();
+    }
   }
-
 }
 
-window.customElements.define('lit-react-wrapper', LitReactWrapper);
+window.customElements.define("lit-react-wrapper", LitReactWrapper);

--- a/lit-react-wrapper.js
+++ b/lit-react-wrapper.js
@@ -40,7 +40,12 @@ export class LitReactWrapper extends LitElement {
       this.shadowRoot.removeChild(this.styleElement);
     }
 
-    const styleContent = Array.isArray(this.styles) ? this.styles.join("\n") : this.styles;
+    let styleContent = "";
+    if (Array.isArray(this.styles)) {
+      styleContent = this.styles.join("\n");
+    } else if (typeof this.styles === "string") {
+      styleContent = this.styles;
+    }
 
     if (styleContent) {
       this.styleElement = document.createElement("style");

--- a/lit-react-wrapper.js
+++ b/lit-react-wrapper.js
@@ -11,7 +11,7 @@ export class LitReactWrapper extends LitElement {
       mountPoint: Object,
       props: Object,
       element: Object,
-      styles: String,
+      styles: Array,
       styleElement: Object,
     };
   }

--- a/lit-react-wrapper.js
+++ b/lit-react-wrapper.js
@@ -12,7 +12,9 @@ export class LitReactWrapper extends LitElement {
       props: Object,
       element: Object,
       styles: Array,
-      styleElement: Object,
+      _styleElement: Object,
+      _reactRef: Object,
+      _reactElement: Object,
     };
   }
 
@@ -20,7 +22,8 @@ export class LitReactWrapper extends LitElement {
     super();
     this.props = {};
     this.styles = [];
-    this.styleElement = null;
+    this._styleElement = null;
+    this._reactRef = React.createRef();
   }
 
   render() {
@@ -31,13 +34,16 @@ export class LitReactWrapper extends LitElement {
     const props = this.props || {};
     if (!props.mountContainer) props.mountContainer = this.mountPoint;
     if (!props.mountDocument) props.mountDocument = this.shadowRoot || document;
-    this.reactElement = React.createElement(this.element, props, React.createElement("slot"));
-    return this.reactElement;
+    this._reactElement = React.createElement(this.element, { ...props, ref: this._reactRef }, React.createElement("slot"));
+    return this._reactElement;
+  }
+  getRef() {
+    return this._reactRef;
   }
 
   injectStyles() {
-    if (this.styleElement && this.shadowRoot.contains(this.styleElement)) {
-      this.shadowRoot.removeChild(this.styleElement);
+    if (this._styleElement && this.shadowRoot.contains(this._styleElement)) {
+      this.shadowRoot.removeChild(this._styleElement);
     }
 
     let styleContent = "";
@@ -48,9 +54,9 @@ export class LitReactWrapper extends LitElement {
     }
 
     if (styleContent) {
-      this.styleElement = document.createElement("style");
-      this.styleElement.textContent = styleContent;
-      this.shadowRoot.insertBefore(this.styleElement, this.mountPoint);
+      this._styleElement = document.createElement("style");
+      this._styleElement.textContent = styleContent;
+      this.shadowRoot.insertBefore(this._styleElement, this.mountPoint);
     }
   }
 

--- a/lit-react-wrapper.js
+++ b/lit-react-wrapper.js
@@ -69,13 +69,12 @@ export class LitReactWrapper extends LitElement {
 
   firstUpdated() {
     this.mountPoint = this.shadowRoot.getElementById("mountPoint");
-    this.injectStyles();
     this.renderElement();
     retargetEvents(this.shadowRoot);
   }
 
   updated(changedProperties) {
-    if (changedProperties.has("styles") || changedProperties.has("element")) {
+    if (changedProperties.has("styles")) {
       this.injectStyles();
     }
     if (changedProperties.has("props") || changedProperties.has("element")) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-react-wrapper",
-  "version": "1.0.3-inject-styles.1",
+  "version": "1.1.0",
   "description": "Use react or material-ui components in your lit-element web component.",
   "main": "lit-react-wrapper.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-react-wrapper",
-  "version": "1.0.2",
+  "version": "1.0.3-inject-styles.0",
   "description": "Use react or material-ui components in your lit-element web component.",
   "main": "lit-react-wrapper.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lit-react-wrapper",
-  "version": "1.0.3-inject-styles.0",
+  "version": "1.0.3-inject-styles.1",
   "description": "Use react or material-ui components in your lit-element web component.",
   "main": "lit-react-wrapper.js",
   "scripts": {


### PR DESCRIPTION
#### Description

1. inject received styles in shadowRoot
2. React element ref

Published locally

#### Usage
```
import "styles" from "my-react-component";
<lit-react-wrapper
  .element=${MyReactComponent}
  .styles=${styles}
  .props=${{
    myProp: myPropValue
  }}
></lit-react-wrapper>
```